### PR TITLE
为实例添加强制类型转换以解决报错

### DIFF
--- a/docs/basic_coding/system/thread.md
+++ b/docs/basic_coding/system/thread.md
@@ -47,7 +47,7 @@ void Blink(int* arg) {
 int main() {
     int arg = 0;
     LibXR::Thread t;
-    t.Create(&arg, Blink, "blink", 2048, LibXR::Thread::Priority::MEDIUM);
+    t.Create((void*)&arg, Blink, "blink", 2048, LibXR::Thread::Priority::MEDIUM);
     // 主线程继续执行其它任务 …
     for (;;) {
         LibXR::Thread::Yield();


### PR DESCRIPTION
源实例的t.Creat函数的第一个参数ArgType要求为(void*)
典型用法中给出的是int arg;
但函数要求void *类型，不添加强制类型转换在此处编译会报错
“
no matching member function for call to 'Create'GCC thread.hpp(64, 8): candidate template ignored: deduced conflicting types for parameter 'ArgType' ('int *' vs. 'void *') ”