### PR TITLE
docs: 补充 app_main.cpp 说明，线程用法和 Clang 构建参数已弃用说明

### DIFF
--- a/docs/adv_coding/uart_driver.md
+++ b/docs/adv_coding/uart_driver.md
@@ -77,7 +77,7 @@ _以下所有驱动的接口都是一致的，以覆盖平台差异_
 
 1. 检查ID是否合法。
 2. uart_handle->Init.Mode分别判断读写是否开启，然后注册读写函数。
-3. 为接收开始DMA，配置为环形，开启空闲中断，直接开始接收。
+3. 将接收DMA配置为环形，开启空闲中断，直接开始接收。
 
 ```cpp
 STM32UART::STM32UART(UART_HandleTypeDef *uart_handle, RawData dma_buff_rx,

--- a/docs/basic_coding/system/thread.md
+++ b/docs/basic_coding/system/thread.md
@@ -33,6 +33,8 @@ sidebar_position: 3
 
 ## 典型用法
 
+线程函数的参数一定要与 `Create` 函数的 `arg` 参数类型一致，否则无法识别。
+
 ```cpp
 #include <thread.hpp>
 
@@ -47,7 +49,7 @@ void Blink(int* arg) {
 int main() {
     int arg = 0;
     LibXR::Thread t;
-    t.Create((void*)&arg, Blink, "blink", 2048, LibXR::Thread::Priority::MEDIUM);
+    t.Create(&arg, Blink, "blink", 2048, LibXR::Thread::Priority::MEDIUM);
     // 主线程继续执行其它任务 …
     for (;;) {
         LibXR::Thread::Yield();

--- a/docs/code_gen/stm32/README.md
+++ b/docs/code_gen/stm32/README.md
@@ -67,6 +67,73 @@ Modifying STM32 interrupt files...
 
 ---
 
+## app_main.cpp
+
+`app_main.cpp` 文件包含了 LibXR 初始化函数 `app_main()`，可以放心的在User Code Begin xxx 和 User Code End xxx 之间插入自己的代码，重新生成后不会被覆盖。
+
+> 此函数应当永不返回，一旦函数返回所有外设对象（如usart1）将会析构并释放资源，此时访问将会导致崩溃。推荐向线程/任务中传递外设对象的基类指针并操作，在本章的`与XRobot集成中`会有更好的方式实现。
+
+```cpp
+#include "app_main.h"
+
+#include "libxr.hpp"
+#include "main.h"
+#include "stm32_adc.hpp"
+#include "stm32_can.hpp"
+#include "stm32_dac.hpp"
+#include "stm32_gpio.hpp"
+#include "stm32_i2c.hpp"
+......
+
+using namespace LibXR;
+
+/* User Code Begin 1 */
+
+/* User Code End 1 */
+/* External HAL Declarations */
+extern ADC_HandleTypeDef hadc1;
+extern CAN_HandleTypeDef hcan1;
+extern I2C_HandleTypeDef hi2c1;
+extern SPI_HandleTypeDef hspi1;
+extern TIM_HandleTypeDef htim1;
+......
+
+/* DMA Resources */
+static uint16_t adc1_buf[64];
+static uint8_t spi1_tx_buf[32];
+static uint8_t spi1_rx_buf[32];
+static uint8_t usart1_tx_buf[128];
+static uint8_t usart1_rx_buf[128];
+static uint8_t i2c1_buf[32];
+......
+
+extern "C" void app_main(void) {
+  /* User Code Begin 2 */
+  
+  /* User Code End 2 */
+  STM32TimerTimebase timebase(&htim2);
+  PlatformInit(2, 2048);
+  STM32PowerManager power_manager;
+
+  /* GPIO Configuration */
+  STM32GPIO USER_KEY(USER_KEY_GPIO_Port, USER_KEY_Pin, EXTI0_IRQn);
+  STM32GPIO LED_B(LED_B_GPIO_Port, LED_B_Pin);
+  STM32PWM pwm_tim1_ch1(&htim1, TIM_CHANNEL_1, false);
+  STM32SPI spi1(&hspi1, spi1_rx_buf, spi1_tx_buf, 3);
+  STM32UART usart1(&huart1,
+              usart1_rx_buf, usart1_tx_buf, 5);
+  STM32I2C i2c1(&hi2c1, i2c1_buf, 3);
+  STM32CAN can1(&hcan1, 5);
+  /* User Code Begin 3 */
+  while (1) {
+      LibXR::Thread::Sleep(1000);
+  }
+  /* User Code End 3 */
+}
+```
+
+---
+
 ## 使用说明
 
 在工程入口处调用 `app_main()`：
@@ -89,18 +156,18 @@ int main() {
 
 ### FreeRTOS 项目
 
-将 `app_main()` 放入主线程入口（StartDefaultTask）中调用。
+将 `app_main()` 放入主线程入口（StartDefaultTask）中调用。注意更改STM32CubeMX中的初始线程大小，避免栈溢出。
 
 ---
 
 ## 可选参数
 
-| 参数       | 说明                        |
-| ---------- | --------------------------- |
-| `-d`       | 指定 STM32 工程根目录       |
-| `-t`       | 设置终端外设（如 `usart1`） |
-| `-c`       | 启用 Clang 构建支持         |
-| `--xrobot` | 生成 XRobot 模块 glue 代码  |
+| 参数       | 说明                          |
+| ---------- | ----------------------------- |
+| `-d`       | 指定 STM32 工程根目录         |
+| `-t`       | 设置终端外设（如 `usart1`）   |
+| `-c`       | 启用 Clang 构建支持（已弃用） |
+| `--xrobot` | 生成 XRobot 模块 glue 代码    |
 
 ---
 

--- a/docs/env_setup/stm32.md
+++ b/docs/env_setup/stm32.md
@@ -39,6 +39,9 @@ sudo ln -s /opt/arm-gun-toolchain-xx.x/bin/* /usr/bin
 
 clang编译器对clangd的支持更好，推荐使用。
 
+2025-7-10：
+STM32CubeMX 15.0更新了对clang编译器的原生支持，不再需要下载llvm，直接使用VSCode插件即可。本节会在有能够独立安装的STARM-CLANG工具链后更新。
+
 ### Windows
 
 下载[LLVM](https://github.com/llvm/llvm-project/tags)并安装，确保版本大于等于18.1。

--- a/i18n/en/docusaurus-plugin-content-docs/current/basic_coding/system/thread.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/basic_coding/system/thread.md
@@ -33,6 +33,8 @@ sidebar_position: 3
 
 ## Typical Usage
 
+The parameter type of the thread function must be consistent with the arg parameter type of the Create function; otherwise, it will not be recognized.
+
 ```cpp
 #include <thread.hpp>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/code_gen/stm32/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/code_gen/stm32/README.md
@@ -67,6 +67,79 @@ After execution, your project directory will contain the following generated or 
 
 ---
 
+## app_main.cpp
+
+The `app_main.cpp` file contains the LibXR initialization function `app_main()`.
+
+You can safely insert your own code between the `User Code Begin xxx` and `User Code End xxx` sections; these parts will not be overwritten when the code is regenerated.
+
+> **Note:**  
+> This function should **never return**. If it does, all peripheral objects (such as `usart1`) will be destructed and resources released, which will cause a crash if you try to access them afterwards.
+
+It is recommended to pass base class pointers of peripheral objects to your threads or tasks and operate on them there.  
+A better way to implement this will be introduced in the section **"Integrate with XRobot"** later in this chapter.
+
+```cpp
+#include "app_main.h"
+
+#include "libxr.hpp"
+#include "main.h"
+#include "stm32_adc.hpp"
+#include "stm32_can.hpp"
+#include "stm32_dac.hpp"
+#include "stm32_gpio.hpp"
+#include "stm32_i2c.hpp"
+......
+
+using namespace LibXR;
+
+/* User Code Begin 1 */
+
+/* User Code End 1 */
+/* External HAL Declarations */
+extern ADC_HandleTypeDef hadc1;
+extern CAN_HandleTypeDef hcan1;
+extern I2C_HandleTypeDef hi2c1;
+extern SPI_HandleTypeDef hspi1;
+extern TIM_HandleTypeDef htim1;
+......
+
+/* DMA Resources */
+static uint16_t adc1_buf[64];
+static uint8_t spi1_tx_buf[32];
+static uint8_t spi1_rx_buf[32];
+static uint8_t usart1_tx_buf[128];
+static uint8_t usart1_rx_buf[128];
+static uint8_t i2c1_buf[32];
+......
+
+extern "C" void app_main(void) {
+  /* User Code Begin 2 */
+  
+  /* User Code End 2 */
+  STM32TimerTimebase timebase(&htim2);
+  PlatformInit(2, 2048);
+  STM32PowerManager power_manager;
+
+  /* GPIO Configuration */
+  STM32GPIO USER_KEY(USER_KEY_GPIO_Port, USER_KEY_Pin, EXTI0_IRQn);
+  STM32GPIO LED_B(LED_B_GPIO_Port, LED_B_Pin);
+  STM32PWM pwm_tim1_ch1(&htim1, TIM_CHANNEL_1, false);
+  STM32SPI spi1(&hspi1, spi1_rx_buf, spi1_tx_buf, 3);
+  STM32UART usart1(&huart1,
+              usart1_rx_buf, usart1_tx_buf, 5);
+  STM32I2C i2c1(&hi2c1, i2c1_buf, 3);
+  STM32CAN can1(&hcan1, 5);
+  /* User Code Begin 3 */
+  while (1) {
+      LibXR::Thread::Sleep(1000);
+  }
+  /* User Code End 3 */
+}
+```
+
+---
+
 ## How to Use
 
 <!-- 将 `app_main()` 放入主线程入口（StartDefaultTask）中调用。 -->
@@ -90,7 +163,8 @@ int main() {
 
 ### FreeRTOS Project
 
-Place `app_main()` in the entry function of the main thread.
+Call `app_main()` in the main thread entry function (such as `StartDefaultTask`).  
+Make sure to adjust the initial thread stack size in STM32CubeMX to avoid stack overflow.
 
 ---
 
@@ -100,7 +174,7 @@ Place `app_main()` in the entry function of the main thread.
 | ---------- | --------------------------------------- |
 | `-d`       | Specify STM32 project root directory    |
 | `-t`       | Set terminal peripheral (e.g. `usart1`) |
-| `-c`       | Enable Clang build support              |
+| `-c`       | Enable Clang build support (Deprecated) |
 | `--xrobot` | Generate glue code for XRobot modules   |
 
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/env_setup/stm32.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/env_setup/stm32.md
@@ -42,6 +42,9 @@ sudo ln -s /opt/arm-gun-toolchain-xx.x/bin/* /usr/bin
 
 clang compiler has better support for clangd, so we recommend using it.
 
+2025-7-10:
+STM32CubeMX 15.0 has added native support for the Clang compiler. There is no need to download LLVM separately; you can use it directly through the VSCode plugin. This section will be updated once an independently installable STARM-CLANG toolchain becomes available.
+
 ### Windows
 
 Download and install [LLVM](https://github.com/llvm/llvm-project/tags). Make sure the version is 18.1 or above.


### PR DESCRIPTION
- 增加 app_main.cpp 使用与生命周期详细示例及注意事项
- 线程函数参数类型一致性说明
- `-c/--clang` 相关参数标记为已弃用，参数表/usage全部补全 Deprecated 说明
- STM32CubeMX 15.0 起原生支持 Clang，env_setup 文档更新